### PR TITLE
fix: make headings and layout mobile-responsive for narrow screens

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -293,7 +293,7 @@ export default function AboutPage() {
           <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
             Expertise
           </p>
-          <h2 className="mt-1 text-2xl font-bold text-navy-900 dark:text-horchata-100">
+          <h2 className="mt-1 text-lg font-bold text-navy-900 dark:text-horchata-100 sm:text-2xl">
             Skills &amp; Technologies 🛠️
           </h2>
           <div className="mt-8 flex flex-wrap gap-2">
@@ -332,7 +332,7 @@ export default function AboutPage() {
             <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
               By the Numbers
             </p>
-            <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+            <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
               Impact at a Glance 📊
             </h2>
           </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -59,7 +59,7 @@ export default function ContactPage() {
             <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
               By the Numbers
             </p>
-            <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+            <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
               Impact at a Glance 📊
             </h2>
           </div>
@@ -101,7 +101,7 @@ export default function ContactPage() {
               <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
                 Let&apos;s Work Together
               </p>
-              <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+              <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
                 Send me a message 💌
               </h2>
               <p className="mt-3 text-lg text-navy-600 dark:text-white/70">

--- a/app/mentoring/page.tsx
+++ b/app/mentoring/page.tsx
@@ -233,7 +233,7 @@ export default function MentoringPage() {
               <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
                 Mentoring
               </p>
-              <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">How I Can Help 🚀</h2>
+              <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">How I Can Help 🚀</h2>
             </div>
           </div>
           <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,7 +81,7 @@ export default async function HomePage() {
                 <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
                   Blog
                 </p>
-                <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+                <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
                   Latest Posts ✍🏽
                 </h2>
               </div>
@@ -126,7 +126,7 @@ export default async function HomePage() {
                   <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
                     Career
                   </p>
-                  <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">Experience 💼</h2>
+                  <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">Experience 💼</h2>
                 </div>
                 <Link
                   href="/about#experience"
@@ -150,7 +150,7 @@ export default async function HomePage() {
                 <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
                   Education
                 </p>
-                <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">Degrees 🎓</h2>
+                <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">Degrees 🎓</h2>
               </div>
               <Link
                 href="/about#education"
@@ -164,7 +164,7 @@ export default async function HomePage() {
                 <Link
                   key={edu.slug}
                   href={`/education/${edu.slug}`}
-                  className="group flex cursor-pointer items-start gap-5 rounded-2xl border border-horchata-200 bg-white p-6 transition-all hover:border-horchata-400 hover:shadow-lg dark:border-navy-700 dark:bg-navy-800 dark:hover:border-navy-500"
+                  className="group flex cursor-pointer items-start gap-4 rounded-2xl border border-horchata-200 bg-white p-4 transition-all hover:border-horchata-400 hover:shadow-lg dark:border-navy-700 dark:bg-navy-800 dark:hover:border-navy-500 sm:gap-5 sm:p-6"
                 >
                   {edu.logo && (
                     <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl bg-horchata-50 dark:bg-navy-700">
@@ -178,7 +178,7 @@ export default async function HomePage() {
                     </div>
                   )}
                   <div className="min-w-0 flex-1">
-                    <h3 className="text-lg font-bold leading-snug text-navy-900 group-hover:text-horchata-700 dark:text-horchata-100 dark:group-hover:text-horchata-300">
+                    <h3 className="text-base font-bold leading-snug text-navy-900 group-hover:text-horchata-700 dark:text-horchata-100 dark:group-hover:text-horchata-300 sm:text-lg">
                       {edu.degree}
                     </h3>
                     <p className="text-sm text-navy-600 dark:text-white/70">
@@ -209,7 +209,7 @@ export default async function HomePage() {
                 <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
                   Pinned
                 </p>
-                <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+                <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
                   Featured Projects ⭐
                 </h2>
               </div>
@@ -276,7 +276,7 @@ export default async function HomePage() {
             <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
               By the Numbers
             </p>
-            <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+            <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
               Impact at a Glance 📊
             </h2>
           </div>

--- a/app/uses/page.tsx
+++ b/app/uses/page.tsx
@@ -397,10 +397,10 @@ export default function UsesPage() {
           <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
             Setup
           </p>
-          <h1 className="mt-2 text-4xl font-bold text-navy-900 dark:text-horchata-100 md:text-5xl">
+          <h1 className="mt-2 text-2xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl md:text-4xl lg:text-5xl">
             What I Use 🛠️
           </h1>
-          <p className="mt-4 max-w-2xl text-lg text-navy-600 dark:text-white/70">
+          <p className="mt-4 max-w-2xl text-base text-navy-600 dark:text-white/70 sm:text-lg">
             Tools, software, MCP servers, plugins, and Claude Code configuration
             that power my daily development workflow.
           </p>
@@ -413,7 +413,7 @@ export default function UsesPage() {
           <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
             Software
           </p>
-          <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+          <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
             Tools & Apps
           </h2>
           <div className="mt-10 space-y-12">
@@ -478,7 +478,7 @@ export default function UsesPage() {
           <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
             AI Workflow
           </p>
-          <h2 className="mt-1 text-3xl font-bold text-navy-900 dark:text-horchata-100">
+          <h2 className="mt-1 text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
             Claude Code Setup
           </h2>
           <p className="mt-4 max-w-2xl text-sm text-navy-600 dark:text-white/70">

--- a/components/sections/connect-cta.tsx
+++ b/components/sections/connect-cta.tsx
@@ -108,10 +108,10 @@ export function ConnectCTA({ variant = "default", sectionClassName }: ConnectCTA
           className="mx-auto mb-6 h-36 w-36 object-contain md:h-40 md:w-40"
           aria-hidden="true"
         />
-        <h2 className="text-3xl font-bold text-navy-900 dark:text-horchata-100">
+        <h2 className="text-xl font-bold text-navy-900 dark:text-horchata-100 sm:text-3xl">
           {v.heading}
         </h2>
-        <p className="mt-3 text-lg text-navy-600 dark:text-white/70">
+        <p className="mt-3 text-base text-navy-600 dark:text-white/70 sm:text-lg">
           {v.description}
         </p>
         <div className="mt-8 flex flex-wrap justify-center gap-4">

--- a/components/sections/organizations-preview.tsx
+++ b/components/sections/organizations-preview.tsx
@@ -20,12 +20,12 @@ export function OrganizationsPreview({
   return (
     <section className="border-y border-horchata-200 bg-horchata-100 py-16 md:py-20 dark:border-navy-700 dark:bg-navy-950">
       <div className="mx-auto max-w-[var(--container-max)] px-6">
-        <div className="mb-8 flex items-end justify-between">
+        <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
               Network
             </p>
-            <h2 className="mt-1 text-2xl font-bold text-navy-900 dark:text-horchata-100">
+            <h2 className="mt-1 text-lg font-bold text-navy-900 dark:text-horchata-100 sm:text-2xl">
               Organizations 🏢
             </h2>
           </div>

--- a/components/sections/testimonials-preview.tsx
+++ b/components/sections/testimonials-preview.tsx
@@ -18,12 +18,12 @@ export function TestimonialsPreview({
   return (
     <section className={sectionClassName ?? "border-y border-horchata-200 bg-horchata-100 py-16 md:py-20 dark:border-navy-700 dark:bg-navy-950"}>
       <div className="mx-auto max-w-[var(--container-max)] px-6">
-        <div className="mb-10 flex items-end justify-between">
+        <div className="mb-10 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
               Testimonials
             </p>
-            <h2 className="mt-1 text-2xl font-bold text-navy-900 dark:text-horchata-100">
+            <h2 className="mt-1 text-lg font-bold text-navy-900 dark:text-horchata-100 sm:text-2xl">
               {heading}
             </h2>
           </div>

--- a/components/sections/timeline-section.tsx
+++ b/components/sections/timeline-section.tsx
@@ -42,7 +42,7 @@ export function TimelineSection({
         <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
           {label}
         </p>
-        <h2 className="mt-1 text-2xl font-bold text-navy-900 dark:text-horchata-100">
+        <h2 className="mt-1 text-lg font-bold text-navy-900 dark:text-horchata-100 sm:text-2xl">
           {heading}
         </h2>
         <div className="mt-8">

--- a/components/ui/back-to-top.tsx
+++ b/components/ui/back-to-top.tsx
@@ -17,7 +17,7 @@ export function BackToTop() {
     <button
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       aria-label="Back to top"
-      className="fixed bottom-16 right-4 z-50 flex h-9 w-9 items-center justify-center rounded-full bg-navy-900 text-white shadow-lg transition-all hover:bg-horchata-700 dark:bg-horchata-600 dark:text-navy-900 dark:hover:bg-horchata-400 sm:bottom-20 sm:right-6 sm:h-10 sm:w-10"
+      className="fixed bottom-16 right-4 z-50 flex h-11 w-11 items-center justify-center rounded-full bg-navy-900 text-white shadow-lg transition-all hover:bg-horchata-700 dark:bg-horchata-600 dark:text-navy-900 dark:hover:bg-horchata-400 sm:bottom-20 sm:right-6"
     >
       <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
         <path d="M18 15l-6-6-6 6" />

--- a/components/ui/back-to-top.tsx
+++ b/components/ui/back-to-top.tsx
@@ -17,7 +17,7 @@ export function BackToTop() {
     <button
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       aria-label="Back to top"
-      className="fixed bottom-20 right-6 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-navy-900 text-white shadow-lg transition-all hover:bg-horchata-700 dark:bg-horchata-600 dark:text-navy-900 dark:hover:bg-horchata-400"
+      className="fixed bottom-16 right-4 z-50 flex h-9 w-9 items-center justify-center rounded-full bg-navy-900 text-white shadow-lg transition-all hover:bg-horchata-700 dark:bg-horchata-600 dark:text-navy-900 dark:hover:bg-horchata-400 sm:bottom-20 sm:right-6 sm:h-10 sm:w-10"
     >
       <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
         <path d="M18 15l-6-6-6 6" />

--- a/components/ui/page-header.tsx
+++ b/components/ui/page-header.tsx
@@ -20,11 +20,11 @@ export function PageHeader({
       <p className="text-sm font-bold uppercase tracking-widest text-horchata-700">
         {label}
       </p>
-      <h1 className="mt-2 text-4xl font-black text-navy-900 dark:text-horchata-100 md:text-5xl">
+      <h1 className="mt-2 text-2xl font-black text-navy-900 dark:text-horchata-100 sm:text-3xl md:text-4xl lg:text-5xl">
         {heading}
       </h1>
       {description && (
-        <p className="mt-4 max-w-2xl text-lg text-navy-600 dark:text-white/70">
+        <p className="mt-4 max-w-2xl text-base text-navy-600 dark:text-white/70 sm:text-lg">
           {description}
         </p>
       )}

--- a/components/ui/timeline.tsx
+++ b/components/ui/timeline.tsx
@@ -36,7 +36,7 @@ export function Timeline({ items, dark }: { items: TimelineItem[]; dark?: boolea
             <p className={`text-xs font-medium ${dark ? "text-white/70" : "text-navy-500 dark:text-horchata-400"}`}>
               {formatDateRange(item.startDate, item.endDate)}
             </p>
-            <h3 className={`mt-1 text-lg font-bold ${dark ? "text-horchata-100" : "text-navy-900 dark:text-horchata-100"}`}>
+            <h3 className={`mt-1 text-base font-bold sm:text-lg ${dark ? "text-horchata-100" : "text-navy-900 dark:text-horchata-100"}`}>
               <Link
                 href={`${item.linkPrefix}/${item.slug}`}
                 className="hover:text-horchata-700 dark:hover:text-horchata-400"


### PR DESCRIPTION
- PageHeader h1: text-4xl → text-2xl sm:text-3xl md:text-4xl lg:text-5xl (prevents emoji orphaning on Pixel-width viewports)
- All section h2s: text-3xl → text-xl sm:text-3xl across home, about, contact, mentoring, uses pages
- ConnectCTA: h2 text-3xl → text-xl sm:text-3xl, description text-lg → text-base sm:text-lg
- TimelineSection h2: text-2xl → text-lg sm:text-2xl
- Timeline item h3: text-lg → text-base sm:text-lg
- OrganizationsPreview + TestimonialsPreview: flex-col on mobile, heading text-2xl → text-lg sm:text-2xl
- Education card: padding p-6 → p-4 sm:p-6, title text-lg → text-base sm:text-lg
- BackToTop: smaller + repositioned on mobile (h-9 w-9, bottom-16 right-4) vs desktop (h-10 w-10, bottom-20 right-6)

Root cause: custom font scale uses 46px for text-3xl and 56px for text-4xl—
much larger than standard Tailwind—causing emoji to wrap to orphaned lines
on ~360dp viewports.

https://claude.ai/code/session_01BrEvVVHLwyVxN6vdAYz9B9