### PR TITLE
perf: improve Lighthouse scores — priority, sizes, contrast

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -77,7 +77,7 @@ export default function ContactPage() {
                     {stat}
                   </p>
                   <p className="mt-0.5 text-sm font-medium text-navy-700 dark:text-white/80">{label}</p>
-                  <p className="text-xs text-navy-400 dark:text-white/40">{sublabel}</p>
+                  <p className="text-xs text-navy-500 dark:text-white/60">{sublabel}</p>
                 </div>
               </Link>
             ))}
@@ -126,7 +126,7 @@ export default function ContactPage() {
                       target="_blank"
                       rel="noopener noreferrer"
                       aria-label={label}
-                      className="flex h-10 w-10 items-center justify-center rounded-xl border border-horchata-200 bg-white text-navy-500 transition-colors hover:border-horchata-400 hover:text-navy-900 dark:border-navy-700 dark:bg-navy-800 dark:text-white/50 dark:hover:border-navy-500 dark:hover:text-white"
+                      className="flex h-10 w-10 items-center justify-center rounded-xl border border-horchata-200 bg-white text-navy-500 transition-colors hover:border-horchata-400 hover:text-navy-900 dark:border-navy-700 dark:bg-navy-800 dark:text-white/70 dark:hover:border-navy-500 dark:hover:text-white"
                     >
                       {icon}
                     </a>

--- a/components/sections/action-cards.tsx
+++ b/components/sections/action-cards.tsx
@@ -68,7 +68,8 @@ export function ActionCards({ cards = defaultCards }: ActionCardsProps) {
               height={96}
               className="h-16 w-16 object-contain sm:h-24 sm:w-24"
               aria-hidden="true"
-              priority={index < 2}
+              sizes="(max-width: 640px) 64px, 96px"
+              loading="lazy"
             />
           </div>
           <div>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -49,6 +49,7 @@ export function Hero() {
                 width={448}
                 height={448}
                 className="h-full w-full rounded-full object-cover ring-4 ring-horchata-200 drop-shadow-lg dark:ring-navy-600"
+                sizes="(max-width: 640px) 224px, (max-width: 768px) 256px, (max-width: 1024px) 288px, (max-width: 1280px) 384px, 448px"
                 priority
               />
             </div>

--- a/components/sections/memoji-section.tsx
+++ b/components/sections/memoji-section.tsx
@@ -50,6 +50,8 @@ export function MemojiSection({ memojis = defaultMemojis }: MemojiSectionProps) 
                 width={120}
                 height={120}
                 className="h-20 w-20 object-contain drop-shadow-md sm:h-24 sm:w-24 md:h-28 md:w-28"
+                sizes="(max-width: 640px) 80px, (max-width: 768px) 96px, 112px"
+                loading="lazy"
               />
               <span className="absolute -bottom-6 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-navy-800 px-2.5 py-1 text-xs font-medium text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 dark:bg-navy-700">
                 {memoji.mood}

--- a/components/ui/contact-form.tsx
+++ b/components/ui/contact-form.tsx
@@ -66,7 +66,7 @@ export function ContactForm() {
       {/* Honeypot */}
       <input type="text" name="_gotcha" style={{ display: "none" }} tabIndex={-1} autoComplete="off" aria-hidden="true" />
 
-      <p className="text-xs text-navy-500 dark:text-white/40">
+      <p className="text-xs text-navy-500 dark:text-white/60">
         Fields marked with <span className="text-red-500" aria-hidden="true">*</span> are required.
       </p>
 


### PR DESCRIPTION
## Summary

Addresses the pre-existing Lighthouse CI failures identified in PR #136.

- **Remove incorrect `priority`** from action-card images — they render below the hero fold, so preloading them competed with the actual LCP element (the profile photo), hurting LCP score
- **Add `sizes` attribute** to hero, action-cards, and memoji-section images so browsers download the correct size variant instead of always fetching the full-resolution image
- **Fix color contrast** on contact page: `white/40` sublabel text and `white/50` social icon color → `white/60`/`white/70` on dark backgrounds; same fix in `contact-form.tsx`

## What this improves

| Issue | Fix |
|---|---|
| LCP score too low | Hero gets full bandwidth (no competing preloads) + correct `sizes` |
| `uses-responsive-images` | `sizes` added to 3 image components |
| `color-contrast` on /contact | Opacity bumped from 40/50 → 60/70 |
| `offscreen-images` | `loading="lazy"` explicit on action-cards + memoji |

## Not addressed here

PNG assets (memoji, speaking-microphone) that Lighthouse flags for `modern-image-formats` — Next.js image optimization converts these to WebP on first request, but the CI runner sees the first uncached request. Proper fix requires pre-converting the PNGs to WebP and committing the WebP files, which is a separate task.

## Test plan

- [ ] Verify home page LCP improves (hero image loads without competition from action card preloads)
- [ ] Verify `/contact` dark mode — sublabel text and social icons are legible
- [ ] Verify Lighthouse CI passes with performance >= 0.8

https://claude.ai/code/session_0134NEfkANysWThC9c8GQeuN

---
_Generated by [Claude Code](https://claude.ai/code/session_0134NEfkANysWThC9c8GQeuN)_